### PR TITLE
[chore/db] supabase used_item과 location 테이블 병합

### DIFF
--- a/src/shared/supabase/types/supabase.d.ts
+++ b/src/shared/supabase/types/supabase.d.ts
@@ -116,41 +116,6 @@ export interface Database {
           }
         ];
       };
-      location: {
-        Row: {
-          address: string;
-          id: number;
-          latitude: string;
-          longitude: string;
-          place_name: string;
-          post_id: number;
-        };
-        Insert: {
-          address: string;
-          id?: number;
-          latitude: string;
-          longitude: string;
-          place_name: string;
-          post_id: number;
-        };
-        Update: {
-          address?: string;
-          id?: number;
-          latitude?: string;
-          longitude?: string;
-          place_name?: string;
-          post_id?: number;
-        };
-        Relationships: [
-          {
-            foreignKeyName: 'location_post_id_fkey';
-            columns: ['post_id'];
-            isOneToOne: false;
-            referencedRelation: 'used_item';
-            referencedColumns: ['id'];
-          }
-        ];
-      };
       main_category: {
         Row: {
           id: number;
@@ -272,36 +237,48 @@ export interface Database {
       };
       used_item: {
         Row: {
+          address: string;
           content: string;
           created_at: string;
           id: number;
+          latitude: string;
+          longitude: string;
           main_category_id: number;
           photo_url: string[];
-          price: string;
+          place_name: string;
+          price: number;
           sold_out: boolean;
           sub_category_id: number;
           title: string;
           user_id: string;
         };
         Insert: {
+          address: string;
           content: string;
           created_at?: string;
           id?: number;
+          latitude: string;
+          longitude: string;
           main_category_id: number;
           photo_url: string[];
-          price?: string;
+          place_name: string;
+          price: number;
           sold_out?: boolean;
           sub_category_id: number;
           title: string;
           user_id: string;
         };
         Update: {
+          address?: string;
           content?: string;
           created_at?: string;
           id?: number;
+          latitude?: string;
+          longitude?: string;
           main_category_id?: number;
           photo_url?: string[];
-          price?: string;
+          place_name?: string;
+          price?: number;
           sold_out?: boolean;
           sub_category_id?: number;
           title?: string;
@@ -395,8 +372,10 @@ export type Tables<
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (Database['public']['Tables'] & Database['public']['Views'])
-    ? (Database['public']['Tables'] & Database['public']['Views'])[PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof (Database['public']['Tables'] &
+        Database['public']['Views'])
+    ? (Database['public']['Tables'] &
+        Database['public']['Views'])[PublicTableNameOrOptions] extends {
         Row: infer R;
       }
       ? R


### PR DESCRIPTION
## 작업 내용

- 1:1 관계의 used_item 테이블과 location 테이블을 병합
  - 이유: 다른 테이블에서 재사용되지 않으므로 조회 속도를 높이고 불필요한 테이블 분리라고 생각해 병합하기로 결정
 
|BEFORE|AFTER|
|--|--|
|![image](https://github.com/nbcamp-mot/puppy-ground/assets/82589401/7cef38fe-d8a9-4d02-bcb2-6a4b7625a389)|![image](https://github.com/nbcamp-mot/puppy-ground/assets/82589401/a6b0888c-51a4-4b94-ba4c-dd0eb27ddd6b)|

## 연관 이슈

- #14 
