### PR TITLE
[feat/used-list] Supabase API 응답을 받아와서 중고 물품 목록 화면 표시

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,5 @@
   "printWidth": 100,
   "useTabs": false,
   "bracketSpacing": true,
-  "endOfLine": "crlf"
+  "endOfLine": "auto"
 }
-

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,17 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  images: {
+    dangerouslyAllowSVG: true,
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'placehold.co',
+        port: '',
+        pathname: '/*'
+      }
+    ]
+  }
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;
+

--- a/src/app/used-goods/_components/UsedGoodsItem.tsx
+++ b/src/app/used-goods/_components/UsedGoodsItem.tsx
@@ -3,14 +3,7 @@ import Link from 'next/link';
 import styled from './usedGoodsItem.module.scss';
 import { UsedItemsWithCategoryAndCount } from '../page';
 import { getStringFromNow } from '@/utils/time';
-
-export function getCountFromTable(column: unknown) {
-  const _column = (Array.isArray(column) ? column[0] : column) as {
-    count?: number;
-  };
-
-  return _column.count ?? null;
-}
+import { getCountFromTable } from '@/utils/table';
 
 const UsedGoodsItem = ({ goods }: { goods: UsedItemsWithCategoryAndCount[number] }) => {
   const { id, created_at, title, photo_url, sold_out, address, price, used_item_wish, chat_list } =

--- a/src/app/used-goods/_components/UsedGoodsItem.tsx
+++ b/src/app/used-goods/_components/UsedGoodsItem.tsx
@@ -1,0 +1,39 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import styled from './usedGoodsItem.module.scss';
+import { UsedItemsWithCategoryAndCount } from '../page';
+import { getStringFromNow } from '@/utils/time';
+
+export function getCountFromTable(column: unknown) {
+  const _column = (Array.isArray(column) ? column[0] : column) as {
+    count?: number;
+  };
+
+  return _column.count ?? null;
+}
+
+const UsedGoodsItem = ({ goods }: { goods: UsedItemsWithCategoryAndCount[number] }) => {
+  const { id, created_at, title, photo_url, sold_out, address, price, used_item_wish, chat_list } =
+    goods;
+
+  return (
+    <div className={styled.container}>
+      <Link href={`used-goods/${id}`}>
+        <div className={styled.goodsImage}>
+          <Image src={photo_url[0]} alt="상품 이미지" width={250} height={250} />
+          {sold_out && <div className={styled.overlay}>판매완료</div>}
+        </div>
+        <div className={styled.goodsInfo}>
+          <h3>{title}</h3>
+          <span>{price}원</span>
+          <time>{getStringFromNow(created_at)}</time>
+          <address>{address}</address>
+          <span>찜 {getCountFromTable(used_item_wish)}</span>
+          <span>채팅 {getCountFromTable(chat_list)}</span>
+        </div>
+      </Link>
+    </div>
+  );
+};
+
+export default UsedGoodsItem;

--- a/src/app/used-goods/_components/UsedGoodsListFilter.tsx
+++ b/src/app/used-goods/_components/UsedGoodsListFilter.tsx
@@ -1,0 +1,5 @@
+const UsedGoodsListFilter = () => {
+  return <div>UsedGoodsListFilter</div>;
+};
+
+export default UsedGoodsListFilter;

--- a/src/app/used-goods/_components/index.ts
+++ b/src/app/used-goods/_components/index.ts
@@ -1,0 +1,4 @@
+import UsedGoodsItem from './UsedGoodsItem';
+import UsedGoodsListFilter from './UsedGoodsListFilter';
+
+export { UsedGoodsItem, UsedGoodsListFilter };

--- a/src/app/used-goods/_components/usedGoodsItem.module.scss
+++ b/src/app/used-goods/_components/usedGoodsItem.module.scss
@@ -1,0 +1,23 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  max-width: 250px;
+  border: 1px solid black;
+  overflow: hidden;
+}
+
+.goodsImage {
+  position: relative;
+}
+
+.overlay {
+  position: absolute;
+  display: block;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 2;
+  text-align: center;
+  color: white;
+}

--- a/src/app/used-goods/page.module.scss
+++ b/src/app/used-goods/page.module.scss
@@ -1,0 +1,8 @@
+.title {
+  font-size: 2rem;
+}
+
+.goodList {
+  display: flex;
+  gap: 1rem;
+}

--- a/src/app/used-goods/page.tsx
+++ b/src/app/used-goods/page.tsx
@@ -1,12 +1,39 @@
-import KakaoMapMarker from '../_components/kakaoMap/KakaoMapMarker';
+import { supabase } from '@/shared/supabase/supabase';
+import { QueryClient } from '@tanstack/react-query';
+import { QueryData } from '@supabase/supabase-js';
+import { UsedGoodsItem, UsedGoodsListFilter } from './_components';
+import styled from './page.module.scss';
 
-const page = () => {
+const usedItemsWithCategoryAndCountQuery = supabase
+  .from('used_item')
+  .select(
+    `id, created_at, title, price, address, sold_out, photo_url, main_category (name), sub_category (name) , used_item_wish ( count ), chat_list ( count )`
+  );
+export type UsedItemsWithCategoryAndCount = QueryData<typeof usedItemsWithCategoryAndCountQuery>;
+export const getUsedGooddsKey = 'used-goods';
+
+export const getUsedGoods = async () => {
+  const { data } = await usedItemsWithCategoryAndCountQuery;
+  return data ?? [];
+};
+
+const UsedGoodsList = async () => {
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: [getUsedGooddsKey],
+    queryFn: getUsedGoods
+  });
+  const usedGoods = queryClient.getQueryData<UsedItemsWithCategoryAndCount>([getUsedGooddsKey]);
+
   return (
     <div>
-      <KakaoMapMarker />
+      <h2 className={styled.title}>중고 물품 리스트</h2>
+      <UsedGoodsListFilter />
+      <div className={styled.goodList}>
+        {usedGoods?.map((goods) => <UsedGoodsItem key={goods.id} goods={goods} />)}
+      </div>
     </div>
   );
 };
 
-export default page;
-
+export default UsedGoodsList;

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -1,0 +1,7 @@
+export function getCountFromTable(column: unknown) {
+  const _column = (Array.isArray(column) ? column[0] : column) as {
+    count?: number;
+  };
+
+  return _column.count ?? null;
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,7 @@
+import moment from 'moment';
+import 'moment/locale/ko';
+
+// timestemp: 2024-01-10T02:13:44+00:0
+export const getStringFromNow = (timestamp: string) => {
+  return moment(timestamp).fromNow();
+};


### PR DESCRIPTION
## 작업 내용
- Supabase API 응답을 받아와서 중고 물품 목록 화면 표시
- util 함수 생성
  - `getStringFromNow`: 현재 시간으로부터 날짜 계산 함수(몇 분 전, 2일 전 등)
  - `getCountFromTable`: `count` 값을 가져오는 함수
- prettier endOfLine 옵션 auto로 변경
  - windows에서는 개행 문자로 CR(Carriage-Return, \r)과 LF(Line Feed, \n)을 사용, Mac은 LF만 사용
  - 운영체제의 개행 문자를 다루는 방식의 차이로 코드 변경 사항이 없더라도 crlf와 lf의 차이로 인해 변경점이 발생
  - [End of Line - Option Prettier](https://prettier.io/docs/en/options.html#end-of-line)
  - ![image](https://github.com/nbcamp-mot/puppy-ground/assets/82589401/7347b28a-96df-47c7-8284-8f220290cdc1)



## 중고 물품 목록 화면
UI 고려 X
![image](https://github.com/nbcamp-mot/puppy-ground/assets/82589401/f2ad971e-1d67-46a6-ab42-a7d96ddf0351)

## `getStringFromNow` 
현재 시간으로부터 날짜 계산 (몇 분 전, 2일 전 등)
### Usage
```ts
import { getStringFromNow } from '@/utils/time';

const created_at = '2024-01-10T02:13:44+00:0'
getStringFromNow(created_at) // 하루 전
```

## `getCountFromTable`
아래의 코드와 같이 `count` 개수를 가져올 때 count 값을 가져오는 함수
```ts
supabase.from('used_item').select(`id, created_at, ... , used_item_wish ( count )`);
```

### Usage
```ts
import { getCountFromTable } from '@/utils/table';

const Component = async () => {
  const data = await supabase.from('used_item').select(`id, created_at, ... , used_item_wish ( count )`);

  return (
    <div>찜 {getCountFromTable(data[0].used_item_wish)}</div>
  )
}
```

## 연관 이슈

- #9 
- close  #20

## TODO
- 중고 물품 목록 필터링