### PR TITLE
[feat/used-detail] 중고 물품 상세 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@supabase/supabase-js": "^2.39.2",
     "@tanstack/react-query": "^5.17.9",
     "axios": "^1.6.5",
+    "classnames": "^2.5.1",
     "framer-motion": "^10.17.9",
     "moment": "^2.30.1",
     "next": "14.0.4",

--- a/src/app/_components/kakaoMap/KakaoMapMarker.tsx
+++ b/src/app/_components/kakaoMap/KakaoMapMarker.tsx
@@ -64,7 +64,6 @@ const KakaoMap = () => {
   return (
     <div className={style['container']}>
       <div id="map" className={style['map-wrap']}>
-        <Script src={KAKAO_SDK_URL} strategy="beforeInteractive" />
         <Map
           center={{ lat: currentLocation.latitude, lng: currentLocation.longitude }}
           level={3}
@@ -102,4 +101,3 @@ const KakaoMap = () => {
 };
 
 export default KakaoMap;
-

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import Header from './_components/layout/Header';
 import Footer from './_components/layout/Footer';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import Script from 'next/script';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -16,9 +17,12 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const KAKAO_SDK_URL = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_APP_KEY}&libraries=services&autoload=false`;
+
   return (
     <html lang="ko">
       <body className={inter.className} suppressHydrationWarning={true}>
+        <Script strategy="beforeInteractive" src={KAKAO_SDK_URL} />
         <ReactQueryProviders>
           <Header />
           {children}
@@ -29,4 +33,3 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     </html>
   );
 }
-

--- a/src/app/used-goods/[id]/page.module.scss
+++ b/src/app/used-goods/[id]/page.module.scss
@@ -1,0 +1,140 @@
+.main {
+  margin: 0 auto;
+  padding: 3rem;
+  max-width: var(--max-width);
+}
+
+.top {
+  margin-bottom: 3rem;
+}
+
+.product {
+  display: flex;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
+}
+
+.imageContainer {
+  margin-right: 2rem;
+  width: fit-content;
+  border: 1px solid rgb(238, 238, 238);
+  border-radius: 15px;
+  overflow: hidden;
+
+  img {
+    border-radius: 15px;
+  }
+
+  @media (max-width: 768px) {
+    margin: 0 auto 2rem auto;
+
+    img {
+      width: 400px;
+      height: 400px;
+    }
+  }
+}
+
+.details {
+  flex-grow: 2;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  .info {
+    margin-bottom: 1rem;
+    h3 {
+      margin-bottom: 1rem;
+      font-size: 1.8rem;
+      line-height: 2rem;
+
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: normal;
+      word-break: keep-all;
+    }
+
+    .price {
+      font-size: 2rem;
+      font-weight: 600;
+      line-height: 2rem;
+    }
+  }
+
+  .profile {
+    margin-bottom: 2rem;
+    display: flex;
+    align-items: center;
+    img {
+      margin-right: 0.6rem;
+      border-radius: 50%;
+    }
+    & > span {
+      font-size: 1.4rem;
+      font-weight: 500;
+    }
+  }
+
+  .moreInfo {
+    margin-bottom: 1rem;
+    time {
+      margin-bottom: 1rem;
+      display: inline-block;
+    }
+    .tag {
+      display: inline-block;
+      padding: 0.8rem 1rem;
+      background-color: rgba(117, 117, 117, 0.1);
+      border-radius: 5px;
+      font-weight: 600;
+      color: rgb(117, 117, 117);
+
+      &:first-child {
+        margin-right: 0.5rem;
+      }
+    }
+  }
+
+  .btns {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    & > button {
+      padding: 0.8rem 4rem;
+      max-width: 300px;
+      background-color: white;
+      border: 2px solid var(--primary-color);
+      border-radius: 15px;
+      font-size: 1.4rem;
+      font-weight: 600;
+      color: var(--primary-color);
+
+      &:last-child {
+        background-color: var(--primary-color);
+        color: white;
+      }
+    }
+  }
+}
+
+.mid,
+.bottom {
+  margin-bottom: 3rem;
+
+  .header {
+    margin-bottom: 2rem;
+    border-bottom: 2px solid #eee;
+    h3 {
+      padding: 1rem 0;
+      font-size: 1.4rem;
+      font-weight: 600;
+      line-height: 2rem;
+    }
+  }
+}

--- a/src/app/used-goods/[id]/page.module.scss
+++ b/src/app/used-goods/[id]/page.module.scss
@@ -128,6 +128,9 @@
   margin-bottom: 3rem;
 
   .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     margin-bottom: 2rem;
     border-bottom: 2px solid #eee;
     h3 {
@@ -135,6 +138,14 @@
       font-size: 1.4rem;
       font-weight: 600;
       line-height: 2rem;
+    }
+    & > p {
+      font-size: 1.2rem;
+
+      svg {
+        margin-right: 3px;
+        transform: translateY(2px);
+      }
     }
   }
 }

--- a/src/app/used-goods/[id]/page.tsx
+++ b/src/app/used-goods/[id]/page.tsx
@@ -5,15 +5,15 @@ import styles from './page.module.scss';
 import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 import { getCountFromTable } from '@/utils/table';
-import KakaoMap from '@/app/_components/kakaoMap/KakaoMapMarker';
 import { getformattedDate } from '@/utils/time';
-import SlideImage from '../_components/SlideImage';
+import { SlideImage, TradeLocationMap } from '../_components';
+import { FaMapMarkerAlt } from 'react-icons/fa';
 
 const getUsedGoodDetail = async (id: string) => {
   const { data, error } = await supabase
     .from('used_item')
     .select(
-      `id, created_at, title, content, price, address, sold_out, photo_url, profiles ( * ), main_category ( name ), sub_category ( name ), used_item_wish ( count ), chat_list ( count )`
+      `*, profiles ( * ), main_category ( name ), sub_category ( name ), used_item_wish ( count ), chat_list ( count )`
     )
     .eq('id', id)
     .single();
@@ -31,13 +31,15 @@ const UsedGoodsDetail = ({ params }: { params: { id: string } }) => {
   if (!data) return null;
 
   const {
-    id,
     created_at,
     title,
     content,
     price,
     profiles,
     photo_url,
+    longitude,
+    latitude,
+    place_name,
     main_category,
     sub_category,
     used_item_wish
@@ -52,13 +54,10 @@ const UsedGoodsDetail = ({ params }: { params: { id: string } }) => {
           </div>
           <div className={styles.details}>
             <div>
-              {/* Info */}
               <div className={styles.info}>
                 <h3 title={title}>{title}</h3>
                 <span className={styles.price}>{price.toLocaleString('ko-KR')}원</span>
               </div>
-
-              {/* Writer */}
               <div className={styles.profile}>
                 {/* TODO: change to avatar_url */}
                 <Image
@@ -69,8 +68,6 @@ const UsedGoodsDetail = ({ params }: { params: { id: string } }) => {
                 />
                 <span>{profiles?.user_name}</span>
               </div>
-
-              {/* Category */}
               <div className={styles.moreInfo}>
                 <time>{getformattedDate(created_at, 'YY년 YY월 DD일')}</time>
                 <div>
@@ -79,7 +76,7 @@ const UsedGoodsDetail = ({ params }: { params: { id: string } }) => {
                 </div>
               </div>
             </div>
-            {/* Buttons */}
+            {/* TODO: 채팅, 찜 기능 동작 */}
             <div className={styles.btns}>
               <button>채팅하기</button>
               <button>찜 {getCountFromTable(used_item_wish)}</button>
@@ -87,7 +84,6 @@ const UsedGoodsDetail = ({ params }: { params: { id: string } }) => {
           </div>
         </div>
       </section>
-
       <section className={styles.mid}>
         <div className={styles.header}>
           <h3>제품 상세 설명</h3>
@@ -96,12 +92,18 @@ const UsedGoodsDetail = ({ params }: { params: { id: string } }) => {
           <p>{content}</p>
         </div>
       </section>
-
       <section className={styles.bottom}>
         <div className={styles.header}>
           <h3>거래 희망 장소</h3>
+          <p>
+            <FaMapMarkerAlt />
+            {place_name}
+          </p>
         </div>
-        <div className={styles.content}>{/* TODO: 장소  */}</div>
+        <div className={styles.content}>
+          <TradeLocationMap lat={latitude} lng={longitude} />
+        </div>
+        {/* TODO: SNS 공유, 링크 복사 */}
       </section>
     </main>
   );

--- a/src/app/used-goods/[id]/page.tsx
+++ b/src/app/used-goods/[id]/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { supabase } from '@/shared/supabase/supabase';
+import styles from './page.module.scss';
+import { useQuery } from '@tanstack/react-query';
+import Image from 'next/image';
+import { getCountFromTable } from '@/utils/table';
+import KakaoMap from '@/app/_components/kakaoMap/KakaoMapMarker';
+import { getformattedDate } from '@/utils/time';
+
+const getUsedGoodDetail = async (id: string) => {
+  const { data, error } = await supabase
+    .from('used_item')
+    .select(
+      `id, created_at, title, content, price, address, sold_out, photo_url, profiles ( * ), main_category ( name ), sub_category ( name ), used_item_wish ( count ), chat_list ( count )`
+    )
+    .eq('id', id)
+    .single();
+
+  return data;
+};
+
+const UsedGoodsDetail = ({ params }: { params: { id: string } }) => {
+  const { isLoading, isError, data } = useQuery({
+    queryKey: ['used-item'],
+    queryFn: () => getUsedGoodDetail(params.id)
+  });
+
+  if (isLoading) return <span>LOADING.....................</span>;
+  if (!data) return null;
+
+  const {
+    id,
+    created_at,
+    title,
+    content,
+    price,
+    profiles,
+    main_category,
+    sub_category,
+    used_item_wish
+  } = data;
+
+  return (
+    <main className={styles.main}>
+      <section className={styles.top}>
+        <div className={styles.product}>
+          <div className={styles.imageContainer}>
+            <Image src={data.photo_url[0]} width="450" height="450" alt="goods item images" />
+          </div>
+          <div className={styles.details}>
+            <div>
+              {/* Info */}
+              <div className={styles.info}>
+                <h3 title={title}>{title}</h3>
+                <span className={styles.price}>{price.toLocaleString('ko-KR')}원</span>
+              </div>
+
+              {/* Writer */}
+              <div className={styles.profile}>
+                {/* TODO: change to avatar_url */}
+                <Image
+                  src={'https://placehold.co/30x30'}
+                  alt="profile image"
+                  width="40"
+                  height="40"
+                />
+                <span>{profiles?.user_name}</span>
+              </div>
+
+              {/* Category */}
+              <div className={styles.moreInfo}>
+                <time>{getformattedDate(created_at, 'YY년 YY월 DD일')}</time>
+                <div>
+                  <span className={styles.tag}>#{main_category!.name}</span>
+                  <span className={styles.tag}>#{sub_category!.name}</span>
+                </div>
+              </div>
+            </div>
+            {/* Buttons */}
+            <div className={styles.btns}>
+              <button>채팅하기</button>
+              <button>찜 {getCountFromTable(used_item_wish)}</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.mid}>
+        <div className={styles.header}>
+          <h3>제품 상세 설명</h3>
+        </div>
+        <div className={styles.content}>
+          <p>{content}</p>
+        </div>
+      </section>
+
+      <section className={styles.bottom}>
+        <div className={styles.header}>
+          <h3>거래 희망 장소</h3>
+        </div>
+        <div className={styles.content}>{/* TODO: 장소  */}</div>
+      </section>
+    </main>
+  );
+};
+
+export default UsedGoodsDetail;

--- a/src/app/used-goods/[id]/page.tsx
+++ b/src/app/used-goods/[id]/page.tsx
@@ -7,6 +7,7 @@ import Image from 'next/image';
 import { getCountFromTable } from '@/utils/table';
 import KakaoMap from '@/app/_components/kakaoMap/KakaoMapMarker';
 import { getformattedDate } from '@/utils/time';
+import SlideImage from '../_components/SlideImage';
 
 const getUsedGoodDetail = async (id: string) => {
   const { data, error } = await supabase
@@ -26,7 +27,7 @@ const UsedGoodsDetail = ({ params }: { params: { id: string } }) => {
     queryFn: () => getUsedGoodDetail(params.id)
   });
 
-  if (isLoading) return <span>LOADING.....................</span>;
+  if (isLoading) return <span>LOADING</span>;
   if (!data) return null;
 
   const {
@@ -36,6 +37,7 @@ const UsedGoodsDetail = ({ params }: { params: { id: string } }) => {
     content,
     price,
     profiles,
+    photo_url,
     main_category,
     sub_category,
     used_item_wish
@@ -46,7 +48,7 @@ const UsedGoodsDetail = ({ params }: { params: { id: string } }) => {
       <section className={styles.top}>
         <div className={styles.product}>
           <div className={styles.imageContainer}>
-            <Image src={data.photo_url[0]} width="450" height="450" alt="goods item images" />
+            <SlideImage images={photo_url} />
           </div>
           <div className={styles.details}>
             <div>

--- a/src/app/used-goods/_components/SlideImage.tsx
+++ b/src/app/used-goods/_components/SlideImage.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence, MotionConfig } from 'framer-motion';
+import { GoDot, GoDotFill, GoChevronLeft, GoChevronRight } from 'react-icons/go';
+import cn from 'classnames/bind';
+import styles from './slideImage.module.scss';
+
+const cx = cn.bind(styles);
+
+const SlideImage = ({ images }: { images: string[] }) => {
+  const [currentIdx, setCurrentIdx] = useState(0);
+
+  const onPrevClick = () => {
+    if (currentIdx > 0) setCurrentIdx((prev) => prev - 1);
+  };
+  const onNextClick = () => {
+    if (currentIdx < images.length - 1) setCurrentIdx((prev) => prev + 1);
+  };
+
+  const onDotClick = (idx: number) => setCurrentIdx(idx);
+
+  const slideVariants = {
+    visible: {
+      opacity: 0
+    },
+    exit: {
+      opacity: 1
+    }
+  };
+
+  return (
+    // TODO: layout shift issue
+    <div className={styles.wrapper}>
+      <MotionConfig transition={{ duration: 0.6 }}>
+        <motion.div>
+          <AnimatePresence>
+            <motion.img
+              key={currentIdx}
+              src={images[currentIdx]}
+              alt={images[currentIdx]}
+              variants={slideVariants}
+              initial="visible"
+              animate="exit"
+              style={{ width: '400px', height: '400px' }}
+            />
+          </AnimatePresence>
+        </motion.div>
+        <motion.div className={cx('directionBtn', 'leftBtn')} onClick={onPrevClick}>
+          <GoChevronLeft size="2rem" />
+        </motion.div>
+        <motion.div className={cx('directionBtn', 'rightBtn')} onClick={onNextClick}>
+          <GoChevronRight size="2rem" />
+        </motion.div>
+        <div className={styles.indicator}>
+          {images.map((_, idx) => (
+            <motion.div key={idx} onClick={() => setCurrentIdx(idx)}>
+              {currentIdx === idx ? <GoDotFill /> : <GoDot />}
+            </motion.div>
+          ))}
+        </div>
+      </MotionConfig>
+    </div>
+  );
+};
+
+export default SlideImage;

--- a/src/app/used-goods/_components/TradeLocationMap.tsx
+++ b/src/app/used-goods/_components/TradeLocationMap.tsx
@@ -3,10 +3,7 @@ import { Map, MapMarker } from 'react-kakao-maps-sdk';
 const TradeLocationMap = ({ lat, lng }: { lat: number; lng: number }) => {
   return (
     <Map
-      center={{
-        lat: 37.464567,
-        lng: 127.538327
-      }}
+      center={{ lat, lng }}
       style={{
         width: '100%',
         height: '450px',

--- a/src/app/used-goods/_components/TradeLocationMap.tsx
+++ b/src/app/used-goods/_components/TradeLocationMap.tsx
@@ -1,0 +1,37 @@
+import { Map, MapMarker } from 'react-kakao-maps-sdk';
+
+const TradeLocationMap = ({ lat, lng }: { lat: number; lng: number }) => {
+  return (
+    <Map
+      center={{
+        lat: 37.464567,
+        lng: 127.538327
+      }}
+      style={{
+        width: '100%',
+        height: '450px',
+        borderRadius: '15px'
+      }}
+      level={3}
+    >
+      <MapMarker
+        position={{ lat, lng }}
+        image={{
+          src: 'https://i.ibb.co/hLdk42x/dog-marker-removebg-preview.png',
+          size: {
+            width: 90,
+            height: 95
+          },
+          options: {
+            offset: {
+              x: 45,
+              y: 70
+            }
+          }
+        }}
+      ></MapMarker>
+    </Map>
+  );
+};
+
+export default TradeLocationMap;

--- a/src/app/used-goods/_components/index.ts
+++ b/src/app/used-goods/_components/index.ts
@@ -1,4 +1,6 @@
 import UsedGoodsItem from './UsedGoodsItem';
 import UsedGoodsListFilter from './UsedGoodsListFilter';
+import SlideImage from './SlideImage';
+import TradeLocationMap from './TradeLocationMap';
 
-export { UsedGoodsItem, UsedGoodsListFilter };
+export { UsedGoodsItem, UsedGoodsListFilter, SlideImage, TradeLocationMap };

--- a/src/app/used-goods/_components/slideImage.module.scss
+++ b/src/app/used-goods/_components/slideImage.module.scss
@@ -1,0 +1,32 @@
+.wrapper {
+  position: relative;
+}
+
+.directionBtn {
+  position: absolute;
+  top: 50%;
+  transform: translate(0, -50%);
+  color: #aaa;
+  cursor: pointer;
+}
+
+.leftBtn {
+  left: 0;
+}
+.rightBtn {
+  right: 0;
+}
+
+.indicator {
+  margin: 0 auto;
+  position: absolute;
+  left: 50%;
+  bottom: 1rem;
+  display: inline-flex;
+  transform: translateX(-50%);
+
+  svg {
+    color: #aaa;
+    cursor: pointer;
+  }
+}

--- a/src/app/used-goods/page.tsx
+++ b/src/app/used-goods/page.tsx
@@ -21,7 +21,8 @@ const UsedGoodsList = async () => {
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({
     queryKey: [getUsedGooddsKey],
-    queryFn: getUsedGoods
+    queryFn: getUsedGoods,
+    staleTime: 1000
   });
   const usedGoods = queryClient.getQueryData<UsedItemsWithCategoryAndCount>([getUsedGooddsKey]);
 

--- a/src/app/variables.css
+++ b/src/app/variables.css
@@ -1,4 +1,4 @@
 :root {
   --max-width: 1200px;
+  --primary-color: #0ac4b9;
 }
-

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -5,3 +5,7 @@ import 'moment/locale/ko';
 export const getStringFromNow = (timestamp: string) => {
   return moment(timestamp).fromNow();
 };
+
+export const getformattedDate = (timestamp: string, format: string) => {
+  return moment(timestamp).format(format);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -616,6 +616,11 @@ chalk@^4.0.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
+classnames@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 client-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"


### PR DESCRIPTION
## 작업 내용
- 중고 물품 상세 페이지 UI 및 기능 연결
- 이미지 슬라이드 
- 거래 희망 장소 지도 표시
- kakao map script 위치 RootLayout으로 변경

|웹|모바일|
|--|--|
|![image](https://github.com/nbcamp-mot/puppy-ground/assets/82589401/3565c6f7-3c26-4c9c-a79f-f664a65f19c3) |![image](https://github.com/nbcamp-mot/puppy-ground/assets/82589401/7bf61a4d-5c73-44dc-a306-0cde9d3a7be0)|

## 연관 이슈

- resolve #10

### 참고
- [classnames](https://www.npmjs.com/package/classnames) 패키지 설치했습니다. yarn 명령어로 설치 부탁드립니다
- kakao map api가 브라우저 상에 노출되는데 은닉하는 방법을 찾아봐야 할 것 같아요

### TODO
- header z-index 수정
- 프로필 클릭 시 마이페이지?
- 일부 css 스타일 개선 ex) 제목이 길어지면 화면 깨짐, 반응형 채팅, 찜 버튼 ..