### PR TITLE
[feat/create-map] 중고물품 등록페이지에 마커 위치정보 zustand로 관리

### DIFF
--- a/src/app/(providers)/stray-dogs/[desertionNo]/page.module.scss
+++ b/src/app/(providers)/stray-dogs/[desertionNo]/page.module.scss
@@ -33,7 +33,7 @@
 }
 
 .titleColumn {
-  width: 30%;
+  width: 20%;
   font-size: 18px;
   line-height: 35px;
   margin: auto 0 auto 100px;

--- a/src/app/_components/kakaoMap/KakaoMapMarker.tsx
+++ b/src/app/_components/kakaoMap/KakaoMapMarker.tsx
@@ -4,6 +4,7 @@ import style from './kakaoMapMarker.module.scss';
 import Script from 'next/script';
 import { Map, MapMarker, MapTypeControl, ZoomControl } from 'react-kakao-maps-sdk';
 import { useState, useEffect } from 'react';
+import { useAddress, usePosition } from '@/hooks/useKakaoMapMarker';
 
 const KAKAO_SDK_URL = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_APP_KEY}&libraries=services&autoload=false`;
 
@@ -12,9 +13,14 @@ const KakaoMapMarker = () => {
     latitude: 33.450701,
     longitude: 126.570667
   });
-  const [position, setPosition] = useState<{ lat: number; lng: number }>();
-  const [address, setAddress] = useState<string>('');
 
+  const setPosition = usePosition((state) => state.setPosition);
+  const setAddress = useAddress((state) => state.setAddress);
+
+  const position = usePosition((state) => state.position);
+  const address = useAddress((state) => state.address);
+
+  // 마커 클릭 시 해당위치 정보 저장
   const mapClickHandler = (_t: any, mouseEvent: any) => {
     const lat = mouseEvent.latLng.getLat();
     const lng = mouseEvent.latLng.getLng();

--- a/src/hooks/useKakaoMapMarker.ts
+++ b/src/hooks/useKakaoMapMarker.ts
@@ -1,0 +1,24 @@
+// import { useCallback, useState } from 'react';
+import { create } from 'zustand';
+
+export type Position = {
+  position: { lat: number; lng: number };
+  setPosition: (position: { lat: number; lng: number }) => void;
+};
+
+export type Address = {
+  address: string;
+  setAddress: (address: string) => void;
+};
+
+const usePosition = create<Position>((set) => ({
+  position: { lat: 0, lng: 0 },
+  setPosition: (position) => set(() => ({ position }))
+}));
+
+const useAddress = create<Address>((set) => ({
+  address: '',
+  setAddress: (address) => set(() => ({ address }))
+}));
+
+export { usePosition, useAddress };


### PR DESCRIPTION
## 작업 내용

>
- hooks 폴더에 useKakaoMapMarker 파일 추가
- 거래위치 선택 시 해당 장소의 위도, 경도, 주소 정보가 데이터에 저장됩니다
<img width="753" alt="스크린샷 2024-01-18 오후 12 06 26" src="https://github.com/nbcamp-mot/puppy-ground/assets/130272838/2f1e46aa-b06c-469a-92a9-61c16b796489">

## 연관 이슈

- close #41 
