### PR TITLE
[feat/used-goods] 중고 물품 목록 이슈 해결

### DIFF
--- a/src/apis/goods.ts
+++ b/src/apis/goods.ts
@@ -22,7 +22,7 @@ export const getUsedGoods = async (params: SearchParams) => {
   else queryFn = queryFn.eq('sold_out', false);
   if (page) {
     const from = (Number(page) - 1) * ITEMS_PER_PAGE;
-    const to = from + ITEMS_PER_PAGE;
+    const to = from + ITEMS_PER_PAGE - 1;
     queryFn = queryFn.range(from, to);
   } else {
     queryFn = queryFn.range(0, ITEMS_PER_PAGE - 1);

--- a/src/app/(providers)/used-goods/[id]/page.module.scss
+++ b/src/app/(providers)/used-goods/[id]/page.module.scss
@@ -71,6 +71,8 @@
     display: flex;
     align-items: center;
     img {
+      width: 40px;
+      height: 40px;
       margin-right: 0.6rem;
       border-radius: 50%;
     }

--- a/src/app/(providers)/used-goods/[id]/page.tsx
+++ b/src/app/(providers)/used-goods/[id]/page.tsx
@@ -178,13 +178,10 @@ const UsedGoodsDetail = ({ params }: { params: { id: string } }) => {
                 <span className={styles.price}>{addCommasToNumber(price)}원</span>
               </div>
               <div className={styles.profile}>
-                {/* TODO: change to avatar_url */}
-                <Image
-                  src={'https://placehold.co/30x30'}
-                  alt="profile image"
-                  width="40"
-                  height="40"
-                />
+                {profiles && (
+                  <Image src={profiles.avatar_url!} alt="profile image" width={40} height={40} />
+                )}
+
                 <span>{profiles?.user_name}</span>
               </div>
               <div className={styles.moreInfo}>

--- a/src/app/(providers)/used-goods/_components/UsedGoodsList.tsx
+++ b/src/app/(providers)/used-goods/_components/UsedGoodsList.tsx
@@ -7,9 +7,12 @@ import { useQueryParam } from '@/hooks/useQueryParam';
 import { getQueryKey, getQueryFunction } from '@/apis/goods';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 
 const UsedGoodsList = () => {
   const { queryObject, generateQueryParameter } = useQueryParam();
+
+  const searchParams = useSearchParams();
   const { data } = useQuery({
     queryKey: getQueryKey(queryObject),
     queryFn: getQueryFunction(queryObject)
@@ -21,11 +24,12 @@ const UsedGoodsList = () => {
     setCurrentPage(pageNumber);
   };
 
-  // TODO: pagination과 query parameter page 동기화
   useEffect(() => {
-    // const { page } = queryObject;
-    // if (!page) setCurrentPage(1);
-  }, [queryObject]);
+    const current = searchParams.get('page');
+    if (!current) return setCurrentPage(1);
+    // TODO: 숫자 아닌 값 방지
+    setCurrentPage(Number(current));
+  }, [searchParams]);
 
   return (
     <>

--- a/src/app/(providers)/used-goods/_components/usedGoodsList.module.scss
+++ b/src/app/(providers)/used-goods/_components/usedGoodsList.module.scss
@@ -1,6 +1,6 @@
 .wrapper {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   row-gap: 4rem;
   column-gap: 2rem;
   padding: 2rem 0;

--- a/src/app/(providers)/used-goods/page.tsx
+++ b/src/app/(providers)/used-goods/page.tsx
@@ -25,7 +25,6 @@ const UsedGoodsContainer = async ({ searchParams }: { searchParams: SearchParams
         </Link>
       </div>
       <HydrationBoundary state={dehydrate(queryClient)}>
-        {/* TODO: 한 줄에 게시글 4개씩 */}
         <UsedGoodsList />
       </HydrationBoundary>
     </main>


### PR DESCRIPTION
## 작업 내용
- 프로필 이미지 경로 지정
- 물품 목록 한 라인에 3개에서 4개 표시되도록 변경
- 페이지 당 물품 9개 가져오는 문제 해결
- 페이지네이션 페이지 번호 동기화

## 연관 이슈

- #58 
