### PR TITLE
[feat/facilities] 동반시설페이지 기능수정

### DIFF
--- a/src/app/(providers)/facilities/page.module.scss
+++ b/src/app/(providers)/facilities/page.module.scss
@@ -16,7 +16,7 @@
   position: absolute;
   left: 0;
   bottom: 40px;
-  width: 300px;
+  width: 320px;
   height: 120px;
   margin-left: -154px;
   text-align: left;

--- a/src/app/(providers)/stray-dogs/[desertionNo]/page.tsx
+++ b/src/app/(providers)/stray-dogs/[desertionNo]/page.tsx
@@ -38,6 +38,9 @@ const StrayDogsDetail = () => {
   });
 
   const formatDate = (dateStr: string) => {
+    if (!dateStr || dateStr.length < 8) {
+      return '날짜 정보 없음';
+    }
     const year = dateStr.substring(0, 4);
     const month = dateStr.substring(4, 6);
     const day = dateStr.substring(6, 8);

--- a/src/app/_components/alertMessage/alertMessageList.module.scss
+++ b/src/app/_components/alertMessage/alertMessageList.module.scss
@@ -1,5 +1,5 @@
 .alertContainer {
-  width: 200px;
+  width: 220px;
   height: 300px;
   background-color: white;
   display: flex;

--- a/src/app/_components/facilities/NearFacilities.tsx
+++ b/src/app/_components/facilities/NearFacilities.tsx
@@ -13,10 +13,11 @@ type NearFacilitiesProps = {
   coordinate: { sw: number[]; ne: number[] };
 };
 const NearFacilities: React.FC<NearFacilitiesProps> = ({ markerFocusHandler, coordinate }) => {
-  const [isVisible, setIsVisible] = useState(true);
+  const [isVisible, setIsVisible] = useState(false);
   const [searchPlace, setSearchPlace] = useState('');
   const [showingData, setShowingData] = useState<Tables<'facilities'>[]>([]);
   const [filteredPlace, setFilteredPlace] = useState<Tables<'facilities'>[] | null>(null);
+  const [serchPerformed, setSearchPerformed] = useState(false);
 
   const { facilitiesData, facilitiesDataByCorrdinate } = useFacilitiesQuery(coordinate);
 
@@ -32,6 +33,7 @@ const NearFacilities: React.FC<NearFacilitiesProps> = ({ markerFocusHandler, coo
 
   // 리스트 검색버튼
   const searchButtonHandler = () => {
+    setSearchPerformed(true);
     if (!facilitiesData?.data) return;
 
     const filteredData = facilitiesData.data.filter((place) => {
@@ -45,6 +47,14 @@ const NearFacilities: React.FC<NearFacilitiesProps> = ({ markerFocusHandler, coo
       );
     });
     setFilteredPlace(filteredData);
+  };
+
+  // 엔터키로 검색처리
+  const enterKeyHandler = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      setSearchPerformed(true);
+      searchButtonHandler();
+    }
   };
 
   // 리스트 열고 닫기 버튼
@@ -71,55 +81,60 @@ const NearFacilities: React.FC<NearFacilitiesProps> = ({ markerFocusHandler, coo
                 className={style.listInput}
                 placeholder="검색어를 입력해주세요"
                 onChange={(e) => setSearchPlace(e.target.value)}
+                onKeyDown={enterKeyHandler}
               />
               <button onClick={() => setSearchPlace('')}>X</button>
               <p>|</p>
               <button onClick={searchButtonHandler}>🔎</button>
             </div>
-            {showingData?.map((list) => {
-              return (
-                <div key={list.id} className={style.listWrap}>
-                  <div className={style.list}>
-                    <div
-                      onClick={() =>
-                        markerFocusHandler({
-                          latitude: list.latitude,
-                          longitude: list.longitude
-                        })
-                      }
-                      className={style.listName}
-                    >
-                      {list.facilities_name}
-                    </div>
-                    <div className={style.listContent}>
-                      <p className={style.listAddress}>
-                        <FaMapMarkerAlt />
-                        &nbsp;{list.address}
-                      </p>
-                      <p>
-                        <TbCategory /> &nbsp;{list.explanation}
-                      </p>
-                      <div className={style.placeOpen}>
-                        <p>
-                          <RiCalendarCloseFill />
-                          &nbsp;{list.holiday}
-                        </p>
-                        <p>
-                          <FaRegClock />
-                          &nbsp;{list.open_time}
-                        </p>
+            {showingData.length === 0 && searchPlace !== '' && serchPerformed ? (
+              <p className={style.noResult}>🥲 검색결과가 없습니다 🥲</p>
+            ) : (
+              showingData?.map((list) => {
+                return (
+                  <div key={list.id} className={style.listWrap}>
+                    <div className={style.list}>
+                      <div
+                        onClick={() =>
+                          markerFocusHandler({
+                            latitude: list.latitude,
+                            longitude: list.longitude
+                          })
+                        }
+                        className={style.listName}
+                      >
+                        {list.facilities_name}
                       </div>
-                      <a href={list.url} target="_blank" rel="noreferrer">
-                        <p className={style.link}>
-                          바로가기 &nbsp;
-                          <FaExternalLinkAlt />
+                      <div className={style.listContent}>
+                        <p className={style.listAddress}>
+                          <FaMapMarkerAlt />
+                          &nbsp;{list.address}
                         </p>
-                      </a>
+                        <p>
+                          <TbCategory /> &nbsp;{list.explanation}
+                        </p>
+                        <div className={style.placeOpen}>
+                          <p>
+                            <RiCalendarCloseFill />
+                            &nbsp;{list.holiday}
+                          </p>
+                          <p>
+                            <FaRegClock />
+                            &nbsp;{list.open_time}
+                          </p>
+                        </div>
+                        <a href={list.url} target="_blank" rel="noreferrer">
+                          <p className={style.link}>
+                            바로가기 &nbsp;
+                            <FaExternalLinkAlt />
+                          </p>
+                        </a>
+                      </div>
                     </div>
                   </div>
-                </div>
-              );
-            })}
+                );
+              })
+            )}
           </div>
         </div>
       )}

--- a/src/app/_components/facilities/nearFacilities.module.scss
+++ b/src/app/_components/facilities/nearFacilities.module.scss
@@ -92,7 +92,7 @@
 
 .listName {
   font-size: 18px;
-  font-weight: 700;
+  font-family: pretendard-medium;
   color: #0ac4b9;
   margin: 5px 0;
   cursor: pointer;
@@ -110,4 +110,10 @@
   font-size: 13px;
   color: #0ac4b9;
   margin-top: 5px;
+}
+
+.noResult {
+  font-family: pretendard-light;
+  font-size: 15px;
+  padding: 20px;
 }


### PR DESCRIPTION
## 작업 내용

> 
- 엔터로 검색가능하도록 수정
- 검색결과 없을때 문구추가 ( 화면영역에 데이터가 없을때는 표시X, 검색결과가 없을때만 표시되도록)

<img width="458" alt="스크린샷 2024-01-30 오후 5 18 47" src="https://github.com/nbcamp-mot/puppy-ground/assets/130272838/6d13f2e6-bfd0-4f4f-864a-dc452e5f0dde">

- 동반시설 페이지 들어왔을때 리스트 열린상태로 수정

<img width="1890" alt="스크린샷 2024-01-30 오후 5 18 36" src="https://github.com/nbcamp-mot/puppy-ground/assets/130272838/ae3be027-b32b-4509-8239-697713f9f5ae">


## 연관 이슈

- close #124 
