### PR TITLE
[feat/mungsta] 멍스타그램 상세페이지 반응형

### DIFF
--- a/src/app/(providers)/@modal/_components/commentList.module.scss
+++ b/src/app/(providers)/@modal/_components/commentList.module.scss
@@ -9,6 +9,7 @@
   display: flex;
   flex-direction: row;
   gap: 10px;
+  flex-grow: 2;
 }
 
 .right {
@@ -27,7 +28,7 @@
   display: flex;
   flex-direction: column;
   gap: 15px;
-  width: 410px;
+  width: 100%;
 
   .name {
     font-size: 1rem;
@@ -64,12 +65,15 @@
 }
 
 .buttonBox {
+  margin-left: 4px;
   display: flex;
   flex-direction: row;
+  width: 55px;
   gap: 10px;
   padding: 10px 0 0 0;
 
   button {
+    min-width: 23px;
     font-size: 0.8rem;
     font-weight: 400;
     color: #a5a5a5;

--- a/src/app/(providers)/mungstagram/_components/detail/MungstaPost.tsx
+++ b/src/app/(providers)/mungstagram/_components/detail/MungstaPost.tsx
@@ -4,19 +4,12 @@ import { getMungstaPost, getComments } from '@/apis/mung-stagram/action';
 import { useQuery } from '@tanstack/react-query';
 import styles from './mungstaPost.module.scss';
 import { useEffect, useState } from 'react';
-import {
-  GoComment,
-  GoShare,
-  GoHeart,
-  GoHeartFill,
-  GoChevronLeft,
-  GoChevronRight
-} from 'react-icons/go';
+import { GoShare, GoChevronLeft, GoChevronRight } from 'react-icons/go';
 import Image from 'next/image';
 import ImageSlider from '@/app/_components/lib/ImageSlider';
-import { getStringFromNow } from '@/utils/time';
 import CommentForm from '@/app/(providers)/@modal/_components/CommentForm';
-import { SlideImage } from '@/app/(providers)/used-goods/_components';
+import { CommentList, LikeButton } from '@/app/(providers)/@modal/_components';
+import KakaoShareButton from '@/app/_components/shareButton/KakaoShareButton';
 
 const MungstaPost = ({ postId }: { postId: string }) => {
   const [mounted, setMounted] = useState<boolean>(false);
@@ -59,7 +52,6 @@ const MungstaPost = ({ postId }: { postId: string }) => {
         <div className={styles.images}>
           {photo_url.length > 1 && (
             <ImageSlider images={photo_url} styles={customStyle} width={500} height={500} />
-            // <SlideImage images={photo_url} width={500} height={500}/>
           )}
           {photo_url.length === 1 && (
             <Image
@@ -75,15 +67,10 @@ const MungstaPost = ({ postId }: { postId: string }) => {
         <div className={styles.details}>
           <div className={styles.top}>
             <div className={styles.icons}>
-              <button>
-                <GoComment size="1.3rem" />
-              </button>
-              <button>
-                <GoHeart size="1.3rem" />
-              </button>
-              <button>
-                <GoShare size="1.3rem" />
-              </button>
+              <LikeButton mungStargramId={postId} title={title} />
+              <KakaoShareButton>
+                <GoShare />
+              </KakaoShareButton>
             </div>
             <div className={styles.hashtags}>
               {tags.map((tag) => (
@@ -102,21 +89,7 @@ const MungstaPost = ({ postId }: { postId: string }) => {
           <span>댓글</span>
         </div>
         <div className={styles.commentList}>
-          {comments.map((comment) => {
-            const { id, content, created_at, profiles } = comment;
-            return (
-              <div className={styles.comment} key={`${id}-${created_at}`}>
-                <div className={styles.avatar}>
-                  <Image src={profiles!.avatar_url!} width={45} height={45} alt="avatar" />
-                </div>
-                <div className={styles.detail}>
-                  <span className={styles.username}>{profiles!.user_name}</span>
-                  <p className={styles.content}>{content}</p>
-                  <span className={styles.createdAt}>{getStringFromNow(created_at)}</span>
-                </div>
-              </div>
-            );
-          })}
+          {mounted && <CommentList />}
           {!comments.length && <div className={styles.comment}>댓글이 없습니다.</div>}
         </div>
         <div className={styles.commentForm}>{mounted && <CommentForm />}</div>

--- a/src/app/(providers)/mungstagram/_components/detail/MungstaPost.tsx
+++ b/src/app/(providers)/mungstagram/_components/detail/MungstaPost.tsx
@@ -4,7 +4,7 @@ import { getMungstaPost, getComments } from '@/apis/mung-stagram/action';
 import { useQuery } from '@tanstack/react-query';
 import styles from './mungstaPost.module.scss';
 import { useEffect, useState } from 'react';
-import { GoShare, GoChevronLeft, GoChevronRight } from 'react-icons/go';
+import { GoShare } from 'react-icons/go';
 import Image from 'next/image';
 import ImageSlider from '@/app/_components/lib/ImageSlider';
 import CommentForm from '@/app/(providers)/@modal/_components/CommentForm';

--- a/src/app/(providers)/mungstagram/_components/detail/mungstaPost.module.scss
+++ b/src/app/(providers)/mungstagram/_components/detail/mungstaPost.module.scss
@@ -65,13 +65,19 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      &:hover {
-        color: red !important;
-      }
+
       span {
         margin-left: 2px;
         font-size: 1.5rem;
-        transform: translate(1px)
+        transform: translate(1px);
+      }
+      &:has(span) {
+        svg {
+          stroke: red;
+          &:hover {
+            color: red !important;
+          }
+        }
       }
     }
     svg {
@@ -139,11 +145,6 @@
   }
 }
 
-.commentList {
-  & > div {
-  }
-}
-
 .comment {
   display: flex;
   .avatar {
@@ -183,5 +184,50 @@
   display: flex;
   & > div {
     width: 100%;
+  }
+}
+
+@media screen and (max-width: 820px) {
+  .main {
+    padding: 1rem;
+    flex-direction: column;
+  }
+
+  .mungsta,
+  .comments {
+    margin: 0 auto;
+    width: 100%;
+    height: 100%;
+  }
+
+  .mungsta {
+    border-radius: 23px 23px 0 0;
+    border-bottom: none;
+
+    .postInfo {
+      min-height: fit-content;
+    }
+  }
+  .comments {
+    border-radius: 0 0 23px 23px;
+    border-top: none;
+    & > div:first-child {
+      order: 0;
+      padding: 0rem 1.4rem;
+    }
+    & > div:nth-child(2) {
+      order: 2;
+      padding: 0 1.4rem 2rem;
+    }
+    & > div:last-child {
+      order: 1;
+      padding: 1rem 1.4rem;
+    }
+  }
+
+  .comments {
+    .commentForm {
+      order: 2;
+    }
   }
 }

--- a/src/app/(providers)/mungstagram/_components/detail/mungstaPost.module.scss
+++ b/src/app/(providers)/mungstagram/_components/detail/mungstaPost.module.scss
@@ -6,11 +6,11 @@
 }
 
 .mungsta {
-  max-width: 500px;
+  width: 500px;
   height: 700px;
   background-color: white;
   border: 2px solid #e6e8e8;
-  border-radius: 23px;
+  border-radius: 23px 0 0 23px;
   overflow: hidden;
 }
 
@@ -57,20 +57,26 @@
 
   .icons {
     display: flex;
-    gap: 4px;
     float: right;
+    gap: 8px;
+    cursor: pointer;
 
-    button {
-      display: block;
-      width: 35px;
-      height: 35px;
-      background-color: transparent;
-      border: none;
-      border-radius: 5px;
-
-      svg {
-        transform: translateY(2px);
+    & > div {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      &:hover {
+        color: red !important;
       }
+      span {
+        margin-left: 2px;
+        font-size: 1.5rem;
+        transform: translate(1px)
+      }
+    }
+    svg {
+      stroke-width: 1.2;
+      font-size: 1.8rem;
     }
   }
 }
@@ -99,7 +105,7 @@
   height: 700px;
   background-color: white;
   border: 2px solid #e6e8e8;
-  border-radius: 23px;
+  border-radius: 0 23px 23px 0;
   overflow: hidden;
 
   .header {
@@ -130,6 +136,11 @@
   &::-webkit-scrollbar-track {
     background-color: #ddd;
     border-radius: 5px;
+  }
+}
+
+.commentList {
+  & > div {
   }
 }
 
@@ -170,7 +181,7 @@
 .commentForm {
   padding: 1rem 2rem;
   display: flex;
-  &  > div {
+  & > div {
     width: 100%;
   }
 }


### PR DESCRIPTION
## 작업 내용
- 멍스타그램 상세페이지 댓글 UI 수정
- 멍스타그램 상세페이지 좋아요, 공유하기 반영
- 멍스타그램 상세페이지 반응형


|PC|Mobile|
|--|--|
| ![image](https://github.com/nbcamp-mot/puppy-ground/assets/82589401/b53ab5d7-0dbd-4c83-b9ed-5ad53cc16bdc) | ![image](https://github.com/nbcamp-mot/puppy-ground/assets/82589401/a78c4789-35bf-494e-bcb6-5be692a00484)|


## 연관 이슈

- #131

## TODO
- 멍스타그램 상세페이지 모달 UI 수정