### PR TITLE
[fix/hydration] hydration 에러 수정

### DIFF
--- a/src/app/(providers)/@modal/_components/CommentList.tsx
+++ b/src/app/(providers)/@modal/_components/CommentList.tsx
@@ -96,7 +96,7 @@ const CommentList = () => {
                 ) : (
                   <div className={styles.content}>{comment.content}</div>
                 )}
-                <time>{getStringFromNow(comment.created_at)}</time>
+                <time suppressHydrationWarning>{getStringFromNow(comment.created_at)}</time>
               </div>
             </div>
           </div>

--- a/src/app/(providers)/profile/_components/Card.tsx
+++ b/src/app/(providers)/profile/_components/Card.tsx
@@ -15,15 +15,15 @@ const Card = ({ goods }: { goods: wishGood }) => {
     <Link href={`/used-goods/${id}`}>
       <div className={styles.container}>
         <div className={styles.image}>
-        <div className={styles.goodsImage}>
-          <Image src={photo_url[0]} alt="상품 이미지" width={250} height={250} />
-          {sold_out && <div className={styles.overlay}></div>}
+          <div className={styles.goodsImage}>
+            <Image src={photo_url[0]} alt="상품 이미지" width={250} height={250} />
+            {sold_out && <div className={styles.overlay}></div>}
           </div>
           <div className={styles.info}>
             <h3>{title}</h3>
             <div className={styles.detail}>
               <span>{addCommasToNumber(price)}원</span>
-              <time>{getStringFromNow(created_at)}</time>
+              <time suppressHydrationWarning>{getStringFromNow(created_at)}</time>
             </div>
             <div className={styles.address}>
               <FaMapMarkerAlt />

--- a/src/app/(providers)/used-goods/_components/UsedGoodsItem.tsx
+++ b/src/app/(providers)/used-goods/_components/UsedGoodsItem.tsx
@@ -35,7 +35,7 @@ const UsedGoodsItem = ({ goods }: UsedGoodsItemProps) => {
           <h3>{title}</h3>
           <div className={styles.detail}>
             <span>{addCommasToNumber(price)}원</span>
-            <time>{getStringFromNow(created_at)}</time>
+            <time suppressHydrationWarning>{getStringFromNow(created_at)}</time>
           </div>
           <div className={styles.address}>
             <FaMapMarkerAlt />


### PR DESCRIPTION
## 작업 내용

- Error: Text content does not match server-rendered HTML.

> 타임스탬프와 같이 서버와 클라이언트 간에 콘텐츠가 필연적으로 다를 수 있습니다. `suppressHydrationWarning={true}`요소에 추가하여 수화 불일치 경고를 음소거할 수 있습니다 .

![image](https://github.com/nbcamp-mot/puppy-ground/assets/82589401/5dae9724-e8be-40c3-88de-4572ecf70bdb)


## 연관 이슈

- #178
