### PR TITLE
[fix/header] 헤더 Layout Shift 해결

### DIFF
--- a/src/app/(providers)/layout.tsx
+++ b/src/app/(providers)/layout.tsx
@@ -3,6 +3,7 @@ import React, { Suspense } from 'react';
 import { ToastContainer } from 'react-toastify';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Footer, Header } from '../_components/layout';
+import HeaderLoading from '../_components/layout/loading/HeaderLoading';
 
 function ProvidersLayout({
   children,
@@ -14,7 +15,7 @@ function ProvidersLayout({
   return (
     <ReactQueryProviders>
       <ReactQueryDevtools initialIsOpen={false} />
-      <Suspense>
+      <Suspense fallback={<HeaderLoading />}>
         <Header />
       </Suspense>
       {children}

--- a/src/app/_components/layout/loading/HeaderLoading.tsx
+++ b/src/app/_components/layout/loading/HeaderLoading.tsx
@@ -1,0 +1,7 @@
+import styles from './headerLoading.module.scss';
+
+const HeaderLoading = () => {
+  return <div className={styles.headerLoading}></div>;
+};
+
+export default HeaderLoading;

--- a/src/app/_components/layout/loading/headerLoading.module.scss
+++ b/src/app/_components/layout/loading/headerLoading.module.scss
@@ -1,0 +1,4 @@
+.headerLoading {
+  height: 100px;
+  background-color: inherit;
+}


### PR DESCRIPTION
## 작업 내용

- 헤더에 React Suspense를 사용하여 로딩되기 전에 헤더가 보이지 않아 Layout Shift 발생
- Suspense의 fallback 속성으로 로딩 컴포넌트를 넣어줌으로써 문제 해결

## 연관 이슈
- #204
